### PR TITLE
Expand environment with external links extension

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         php: [7.4, 8.0, 8.1]
-        laravel: [9.*, 8.*, 7.*]
+        laravel: [9.*, 8.*]
         dependency-version: [prefer-lowest, prefer-stable]
         os: [ubuntu-latest]
         include:
@@ -20,8 +20,6 @@ jobs:
             laravel-constraint: ^8.18.1
           - laravel: 8.*
             testbench: 6.*
-          - laravel: 7.*
-            testbench: 5.*
           - php: 7.4
             dependency-version: prefer-lowest
             additional-deps: '"mockery/mockery:>=1.2.3"'
@@ -33,8 +31,6 @@ jobs:
             laravel: 9.*
           - php: 8.1
             laravel: 8.*
-          - php: 8.1
-            laravel: 7.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
   "require": {
     "php": "^7.0|^8.0",
     "illuminate/support": "^7.0|^8.0|^9.0",
-    "league/commonmark": "^1.5|^2.0"
+    "league/commonmark": "^2.0"
   },
   "require-dev": {
     "orchestra/testbench": "^6.0",

--- a/src/Markdown/CommonMarkRepository.php
+++ b/src/Markdown/CommonMarkRepository.php
@@ -2,8 +2,8 @@
 
 namespace VV\Markdown\Markdown;
 
-use League\CommonMark\Environment;
-use League\CommonMark\Extension\CommonMarkCoreExtension;
+use League\CommonMark\Environment\Environment;
+use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
 use League\CommonMark\Extension\GithubFlavoredMarkdownExtension;
 use League\CommonMark\Extension\ExternalLink\ExternalLinkExtension;
 use League\CommonMark\CommonMarkConverter;

--- a/src/Markdown/CommonMarkRepository.php
+++ b/src/Markdown/CommonMarkRepository.php
@@ -6,7 +6,7 @@ use League\CommonMark\Environment;
 use League\CommonMark\Extension\CommonMarkCoreExtension;
 use League\CommonMark\Extension\GithubFlavoredMarkdownExtension;
 use League\CommonMark\Extension\ExternalLink\ExternalLinkExtension;
-use League\CommonMark\MarkdownConverter;
+use League\CommonMark\CommonMarkConverter;
 
 class CommonMarkRepository implements MarkdownRepository
 {
@@ -21,7 +21,7 @@ class CommonMarkRepository implements MarkdownRepository
         $environment->addExtension(new GithubFlavoredMarkdownExtension());
         $environment->addExtension(new ExternalLinkExtension());
 
-        $this->parser = new MarkdownConverter($environment);
+        $this->parser = new CommonMarkConverter($environment);
     }
 
     public function parse(string $content): string

--- a/src/Markdown/CommonMarkRepository.php
+++ b/src/Markdown/CommonMarkRepository.php
@@ -10,7 +10,7 @@ use League\CommonMark\MarkdownConverter;
 
 class CommonMarkRepository implements MarkdownRepository
 {
-    public GithubFlavoredMarkdownConverter $parser;
+    public MarkdownConverter $parser;
 
     public string $style = 'default';
 

--- a/src/Markdown/CommonMarkRepository.php
+++ b/src/Markdown/CommonMarkRepository.php
@@ -6,7 +6,7 @@ use League\CommonMark\Environment\Environment;
 use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
 use League\CommonMark\Extension\GithubFlavoredMarkdownExtension;
 use League\CommonMark\Extension\ExternalLink\ExternalLinkExtension;
-use League\CommonMark\CommonMarkConverter;
+use League\CommonMark\MarkdownConverter;
 
 class CommonMarkRepository implements MarkdownRepository
 {
@@ -21,7 +21,7 @@ class CommonMarkRepository implements MarkdownRepository
         $environment->addExtension(new GithubFlavoredMarkdownExtension());
         $environment->addExtension(new ExternalLinkExtension());
 
-        $this->parser = new CommonMarkConverter($environment);
+        $this->parser = new MarkdownConverter($environment);
     }
 
     public function parse(string $content): string

--- a/src/Markdown/CommonMarkRepository.php
+++ b/src/Markdown/CommonMarkRepository.php
@@ -19,7 +19,10 @@ class CommonMarkRepository implements MarkdownRepository
         $environment = new Environment($config);
         $environment->addExtension(new CommonMarkCoreExtension());
         $environment->addExtension(new GithubFlavoredMarkdownExtension());
-        $environment->addExtension(new ExternalLinkExtension());
+
+        if (key($config) === "external_link") {
+            $environment->addExtension(new ExternalLinkExtension());
+        }
 
         $this->parser = new MarkdownConverter($environment);
     }

--- a/src/Markdown/CommonMarkRepository.php
+++ b/src/Markdown/CommonMarkRepository.php
@@ -20,11 +20,11 @@ class CommonMarkRepository implements MarkdownRepository
         $environment->addExtension(new CommonMarkCoreExtension());
         $environment->addExtension(new GithubFlavoredMarkdownExtension());
 
-        foreach ($config as $key => $value) {
+        collect($config)->each(function($item) use ($environment) {
             if ($key === 'external_link') {
                 $environment->addExtension(new ExternalLinkExtension());
             }
-        }
+        });
 
         $this->parser = new MarkdownConverter($environment);
     }
@@ -37,7 +37,7 @@ class CommonMarkRepository implements MarkdownRepository
         return (new AddCustomHtmlClasses($content, $this->style))->handle();
     }
 
-    public function style(string $style): self
+    public function style(string $style): CommonMarkRepository
     {
         $this->style = $style;
 

--- a/src/Markdown/CommonMarkRepository.php
+++ b/src/Markdown/CommonMarkRepository.php
@@ -2,7 +2,11 @@
 
 namespace VV\Markdown\Markdown;
 
-use League\CommonMark\GithubFlavoredMarkdownConverter;
+use League\CommonMark\Environment\Environment;
+use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
+use League\CommonMark\Extension\GithubFlavoredMarkdownExtension;
+use League\CommonMark\Extension\ExternalLink\ExternalLinkExtension;
+use League\CommonMark\MarkdownConverter;
 
 class CommonMarkRepository implements MarkdownRepository
 {
@@ -12,7 +16,12 @@ class CommonMarkRepository implements MarkdownRepository
 
     public function __construct(array $config)
     {
-        $this->parser = new GithubFlavoredMarkdownConverter($config);
+        $environment = new Environment($config);
+        $environment->addExtension(new CommonMarkCoreExtension());
+        $environment->addExtension(new GithubFlavoredMarkdownExtension());
+        $environment->addExtension(new ExternalLinkExtension());
+
+        $this->parser = new MarkdownConverter($environment);
     }
 
     public function parse(string $content): string

--- a/src/Markdown/CommonMarkRepository.php
+++ b/src/Markdown/CommonMarkRepository.php
@@ -21,7 +21,7 @@ class CommonMarkRepository implements MarkdownRepository
         $environment->addExtension(new GithubFlavoredMarkdownExtension());
 
         foreach ($config as $key => $value) {
-            if ($key === "external_link") {
+            if ($key === 'external_link') {
                 $environment->addExtension(new ExternalLinkExtension());
             }
         }

--- a/src/Markdown/CommonMarkRepository.php
+++ b/src/Markdown/CommonMarkRepository.php
@@ -2,7 +2,7 @@
 
 namespace VV\Markdown\Markdown;
 
-use League\CommonMark\Environment\Environment;
+use League\CommonMark\Environment;
 use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
 use League\CommonMark\Extension\GithubFlavoredMarkdownExtension;
 use League\CommonMark\Extension\ExternalLink\ExternalLinkExtension;

--- a/src/Markdown/CommonMarkRepository.php
+++ b/src/Markdown/CommonMarkRepository.php
@@ -3,7 +3,7 @@
 namespace VV\Markdown\Markdown;
 
 use League\CommonMark\Environment;
-use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
+use League\CommonMark\Extension\CommonMarkCoreExtension;
 use League\CommonMark\Extension\GithubFlavoredMarkdownExtension;
 use League\CommonMark\Extension\ExternalLink\ExternalLinkExtension;
 use League\CommonMark\MarkdownConverter;

--- a/src/Markdown/CommonMarkRepository.php
+++ b/src/Markdown/CommonMarkRepository.php
@@ -20,8 +20,10 @@ class CommonMarkRepository implements MarkdownRepository
         $environment->addExtension(new CommonMarkCoreExtension());
         $environment->addExtension(new GithubFlavoredMarkdownExtension());
 
-        if (key($config) === "external_link") {
-            $environment->addExtension(new ExternalLinkExtension());
+        foreach ($config as $key => $value) {
+            if ($value['internal_hosts'] !== config('app.url')) {
+                $environment->addExtension(new ExternalLinkExtension());
+            }
         }
 
         $this->parser = new MarkdownConverter($environment);

--- a/src/Markdown/CommonMarkRepository.php
+++ b/src/Markdown/CommonMarkRepository.php
@@ -21,7 +21,7 @@ class CommonMarkRepository implements MarkdownRepository
         $environment->addExtension(new GithubFlavoredMarkdownExtension());
 
         foreach ($config as $key => $value) {
-            if ($value['internal_hosts'] !== config('app.url')) {
+            if ($key === "external_link") {
                 $environment->addExtension(new ExternalLinkExtension());
             }
         }


### PR DESCRIPTION
With this pull request, external links can be configured in the `Markdown.php` configuration file.